### PR TITLE
write update logs to file

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+wb-update-manager (1.2.0) stable; urgency=medium
+
+  * write update logs to file in /var/log/wb-release
+  * run apt dist-upgrade in two stages (simulate + upgrade) by default
+  * always run apt in non-interactive mode for correct logging
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Thu, 21 Oct 2021 13:29:25 +0300
+
 wb-update-manager (1.1.1) stable; urgency=medium
 
   * add unit tests


### PR DESCRIPTION
 * add -l flag to set log filename (+ default log location in /var/log)
 * always run apt in non-interactive mode
 * run dist-upgrade in simulate mode before actual update
   if started without -y flag