### PR TITLE
more proper upgrade error handling

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+wb-update-manager (1.2.2) stable; urgency=medium
+
+  * run autoremove without confirmation
+  * cleanup apt lists cache on errors
+  * retry upgrade if system state is inconsistent (interrupted during
+    dist-upgrade)
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Sun, 26 Dec 2021 15:21:09 +0300
+
 wb-update-manager (1.2.0) stable; urgency=medium
 
   * write update logs to file in /var/log/wb-release

--- a/tests/data/sources.1.list
+++ b/tests/data/sources.1.list
@@ -1,0 +1,5 @@
+# test comment
+# more comments here
+#   even this
+#deb http://non.existing.org/debian release main
+deb http://deb.wirenboard.com/wb6/stretch wb-2108 main

--- a/tests/data/sources.2.list
+++ b/tests/data/sources.2.list
@@ -1,0 +1,3 @@
+debs wrong line
+deb http://deb.wirenboard.com/wb6/stretch wb-2108 main
+deb http://deb.wirenboard.com/wb6/stretch testing main

--- a/tests/data/sources.3.list
+++ b/tests/data/sources.3.list
@@ -1,0 +1,1 @@
+deb http://deb.wirenboard.com/wb6/stretch testing main

--- a/tests/data/sources.4.list
+++ b/tests/data/sources.4.list
@@ -1,0 +1,1 @@
+deb http://deb.wirenboard.com/wb6/stretch stable main


### PR DESCRIPTION
 * run autoremove without confirmation
 * cleanup apt lists cache on errors
 * detect inconsistent system state if upgrade failed (wb-release is new
   but apt lists are old) and retry on request