### PR TITLE
remove "Update to Debian Bullseye" message

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-update-manager (1.2.7) stable; urgency=medium
+
+  * remove 'Update to Debian Bullseye available' message
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Mon, 17 Oct 2022 13:36:37 +0600
+
 wb-update-manager (1.2.6) stable; urgency=medium
 
   * format source code with black

--- a/debian/wb-update-manager.postinst
+++ b/debian/wb-update-manager.postinst
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -e
+
+#DEBHELPER#
+
+rm -rf /etc/update-motd.d/99-wb-bullseye-available


### PR DESCRIPTION
После обновления на bullseye остаётся сообщение в баннере (после установки пакетов из ветки https://github.com/wirenboard/wb-update-manager/tree/release/bullseye-upgrade). По идее, надо было изначально сделать так, чтобы dpkg не считал файл с этим сообщением за conffile (тогда он бы удалился сам), но сейчас с этим лень разбираться и не вижу ничего зазорного в получившемся решении.