### PR TITLE
fix reboot reminder message install

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-update-manager (1.2.5-upgrade4) stable; urgency=medium
+
+  * fix reboot reminder message installation
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Wed, 19 Oct 2022 19:26:30 +0600
+
 wb-update-manager (1.2.5-upgrade3) stable; urgency=medium
 
   * Add notice about Debian Bullseye to login message

--- a/wb/update_manager/release.py
+++ b/wb/update_manager/release.py
@@ -535,6 +535,9 @@ def upgrade_new_debian_release(state: SystemState, log_filename, assume_yes=Fals
         atexit.unregister(restore_debian_sources_lists)
         restore_debian_sources_lists()
 
+        logger.info('Copying restart-required motd message from current wb-update-manager version')
+        shutil.copy('/usr/share/wb-update-manager/99-wb-debian-release-updated', '/etc/update-motd.d/')
+
         logger.info('Updating openssh-server first to make Wiren Board available during update')
         run_cmd('systemctl', 'mask', 'ssh.service')
         run_apt('install', 'openssh-server', assume_yes=not confirm_steps)
@@ -580,7 +583,6 @@ def upgrade_new_debian_release(state: SystemState, log_filename, assume_yes=Fals
         logger.info('Cleaning up old packages')
         run_apt('autoremove', assume_yes=not confirm_steps)
 
-        shutil.copy('/usr/share/wb-update-manager/99-wb-debian-release-updated', '/etc/update-motd.d/')
         open('/run/wb-debian-release-updated', 'w').close()
 
         logger.info('Done! Please reboot system')


### PR DESCRIPTION
В конце процесса обновления через wb-release выводится такая ошибка:

```
...
13:13:05 Removing sudo (1.9.5p2-3) ...
13:13:05 Removing tcpd (7.6.q-31) ...
13:13:06 Processing triggers for mailcap (3.69) ...
13:13:06 Processing triggers for libc-bin (2.31-13+deb11u4) ...
13:13:08 Something went wrong, check output and try again
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/wb/update_manager/release.py", line 583, in upgrade_new_debian_release
  File "/usr/lib/python3.5/shutil.py", line 241, in copy
  File "/usr/lib/python3.5/shutil.py", line 120, in copyfile
FileNotFoundError: [Errno 2] No such file or directory: '/usr/share/wb-update-manager/99-wb-debian-release-updated'
13:13:08 Removing temp debian-upstream sources list file
```

Сам процесс обновления не затронут, всё уже готово к этому моменту, только не выводится напоминание о том, что нужно перезагрузить контроллер.

Раньше не стреляло, потому что при обновлении оставалась та же версия wb-update-manager, что и была до обновления, и файл никуда не девался.