### PR TITLE
add Bullseye-related tips

### DIFF
--- a/bin/98-wb-bullseye-update-tips
+++ b/bin/98-wb-bullseye-update-tips
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+if [ -e /var/lib/wirenboard/disable-bullseye-tips ]; then
+    exit 0
+fi
+
+/usr/lib/wb-update-manager/bullseye-update-tips 2>/dev/null || exit 0

--- a/bin/bullseye-tips.d/10repositories
+++ b/bin/bullseye-tips.d/10repositories
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+if [ "$LANG" == "ru-RU.UTF-8" ]; then
+    HEADER="Найдены потенциально устаревшие репозитории в файлах:"
+    FOOTER="Измените эти файлы вручную."
+else
+    HEADER="There are potentially obsolete sources lists in:"
+    FOOTER="Please modify these files manually."
+fi
+
+OBSOLETES=()
+
+for file in /etc/apt/sources.list.d/*; do
+    if grep -qE '^\s*deb.*(buster|stretch|wheezy)' "$file"; then
+        OBSOLETES+=( "$file" )
+    fi
+done
+
+if [[ ${#OBSOLETES[@]} -gt 0 ]]; then
+    echo " $HEADER"
+    echo ""
+    for file in "${OBSOLETES[@]}"; do
+        echo "  * $file"
+    done
+    echo ""
+    echo " $FOOTER"
+    echo ""
+fi

--- a/bin/bullseye-update-tips
+++ b/bin/bullseye-update-tips
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+run-parts /usr/lib/wb-update-manager/bullseye-tips.d/

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-update-manager (1.3.0) stable; urgency=medium
+
+  * add Bullseye-related tips to motd (potentially obsolete repositories)
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Mon, 24 Oct 2022 16:26:54 +0600
+
 wb-update-manager (1.2.7) stable; urgency=medium
 
   * remove 'Update to Debian Bullseye available' message

--- a/debian/wb-update-manager.install
+++ b/debian/wb-update-manager.install
@@ -1,1 +1,4 @@
 bin/wb-release /usr/bin
+bin/98-wb-bullseye-update-tips /etc/update-motd.d
+bin/bullseye-update-tips /usr/lib/wb-update-manager/
+bin/bullseye-tips.d/ /usr/lib/wb-update-manager/


### PR DESCRIPTION
По просьбе пользователей из чата добавил скрипт, который подсказывает, что после обновления в `/etc/apt/sources.list.d` остались потенциально устаревшие репозитории.

Также сделал инфраструктуру вокруг подобных подсказок, так что можно будет так же рассказать про network-manager потом.

Отдельным PR сделаю вывод этих подсказок в конце процесса обновления до bullseye.

Выглядит это так:

```console
          _                _                         _ 
__      _(_)_ __ ___ _ __ | |__   ___   __ _ _ __ __| |
\ \ /\ / / | '__/ _ \ '_ \| '_ \ / _ \ / _` | '__/ _` |
 \ V  V /| | | |  __/ | | | |_) | (_) | (_| | | | (_| |
  \_/\_/ |_|_|  \___|_| |_|_.__/ \___/ \__,_|_|  \__,_|
                                                       
Welcome to Wiren Board 7.2.1 (s/n ATHFDT4L), release staging.05609.74cabaf2f2a1 (as testing)
Linux wirenboard-ATHFDT4L 5.10.35-wb120 #1 SMP Fri Sep 2 07:33:43 UTC 2022 armv7l GNU/Linux

 There are potentially obsolete sources lists in:

  * /etc/apt/sources.list.d/nodesource.list

 Please modify these files manually.

Last login: Mon Oct 24 11:16:46 2022 from 192.168.0.104
root@wirenboard-ATHFDT4L:~#
```