### PR TITLE
break on updated tool available + restart wb-release after initial update

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-update-manager (1.2.5-upgrade5) stable; urgency=medium
+
+  * break Debian release update process if updated tool is available
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Wed, 26 Oct 2022 19:03:53 +0600
+
 wb-update-manager (1.2.5-upgrade4) stable; urgency=medium
 
   * fix reboot reminder message installation

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 wb-update-manager (1.2.5-upgrade5) stable; urgency=medium
 
   * break Debian release update process if updated tool is available
+  * restart wb-release tool after initial apt-upgrade on Debian release update
 
  -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Wed, 26 Oct 2022 19:03:53 +0600
 

--- a/debian/wb-update-manager.postinst
+++ b/debian/wb-update-manager.postinst
@@ -1,0 +1,23 @@
+#!/bin/bash -e
+
+#DEBHELPER#
+
+# Until 1.2.5-upgrade5 wb-release tool did not restart itself after update
+# during Debian release update. This forbids updating using outdated tool.
+
+if [[ "$1" = "configure" ]] && [[ -n "$2" ]] && dpkg --compare-versions "$2" lt "1.2.5-upgrade5~~"; then
+    if [[ ! -e "/run/wb-release-tool-updated" ]] && pgrep -f wb-release >/dev/null; then
+        cat <<EOF
+
+###########################################################
+#                                                         #
+#            wb-release tool is updated!                  #
+#                                                         #
+#  Please ignore error and run wb-release command again.  #
+#                                                         #
+###########################################################
+
+EOF
+        exit 1
+    fi
+fi

--- a/wb/update_manager/release.py
+++ b/wb/update_manager/release.py
@@ -498,6 +498,10 @@ def upgrade_new_debian_release(state: SystemState, log_filename, assume_yes=Fals
 
                          Make sure you have all your data backed up.""").strip(), assume_yes)
 
+        # create flag which allows wb-update-manager to finish upgrade
+        with open("/run/wb-release-tool-updated", "wb"):
+            pass
+
         logger.info('Performing upgrade on the current release')
         run_system_update(assume_yes)
         new_state = state._replace(target=(controller_version + '/bullseye'))

--- a/wb/update_manager/release.py
+++ b/wb/update_manager/release.py
@@ -467,7 +467,8 @@ def _free_space_mb(path):
     return stat.f_bavail * stat.f_bsize / 1024 / 1024
 
 
-def upgrade_new_debian_release(state: SystemState, log_filename, assume_yes=False, confirm_steps=False):
+def upgrade_new_debian_release(state: SystemState, log_filename, assume_yes=False, confirm_steps=False,
+                               no_preliminary_update=False):
     # these services will be masked (preventing restart during update)
     # and then restarted manually
     SERVICES_TO_RESTART = ('nginx.service', 'mosquitto.service', 'wb-mqtt-mbgate.service')
@@ -490,20 +491,38 @@ def upgrade_new_debian_release(state: SystemState, log_filename, assume_yes=Fals
     controller_version = m.group(1)
 
     try:
-        user_confirm(textwrap.dedent("""
-                         Now the system will be updated using Apt without changing the release.
+        if not no_preliminary_update:
+            user_confirm(textwrap.dedent("""
+                             Now the system will be updated using Apt without changing the release.
 
-                         It is required to get latest state possible
-                         to make release change process more controllable.
+                             It is required to get latest state possible
+                             to make release change process more controllable.
 
-                         Make sure you have all your data backed up.""").strip(), assume_yes)
+                             Make sure you have all your data backed up.""").strip(), assume_yes)
 
-        # create flag which allows wb-update-manager to finish upgrade
-        with open("/run/wb-release-tool-updated", "wb"):
-            pass
+            # create flag which allows wb-update-manager to finish upgrade
+            with open("/run/wb-release-tool-updated", "wb"):
+                pass
 
-        logger.info('Performing upgrade on the current release')
-        run_system_update(assume_yes)
+            logger.info('Performing upgrade on the current release')
+            run_system_update(assume_yes)
+
+            logger.info('Starting (possibly updated) update utility as new process')
+            args = sys.argv + ['--no-preliminary-update']
+
+            # preserve update log filename from the first stage
+            if log_filename:
+                args += ['--log-filename', log_filename]
+
+            # close log handlers in this instance to make it free for second one
+            for h in logger.handlers:
+                h.close()
+
+            os.execvp(args[0], args)
+
+            logger.fatal('Should not be here after execvp!')
+            return 1
+
         new_state = state._replace(target=(controller_version + '/bullseye'))
         if not release_exists(new_state):
             logger.error('Target state does not exist: {}'.format(new_state))
@@ -626,7 +645,8 @@ def route(args, argv):
 
     if args.update_debian_release:
         return upgrade_new_debian_release(current_state, log_filename=args.log_filename,
-                                          assume_yes=args.yes, confirm_steps=args.confirm_steps)
+                                          assume_yes=args.yes, confirm_steps=args.confirm_steps,
+                                          no_preliminary_update=args.second_stage)
 
     if args.regenerate:
         return generate_system_config(current_state)


### PR DESCRIPTION
Проморгал тот факт, что wb-release не перезапускает себя после первичного обновления во время перехода на bullseye (эта процедура есть при смене релизов).

Добавил перезапуск утилиты после первичного обновления.

Для более старых версий wb-update-manager подкрутил postinst, чтобы обновление сломалось при использовании старой версии wb-release, при этом выводится сообщение о том, что можно смело перезапускать утилиту и всё будет хорошо.