### PR TITLE
fix updated tool panic during release switch within stretch

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-update-manager (1.2.5-upgrade6) stable; urgency=medium
+
+  * fix updated wb-release's panic during release switch within stretch
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Tue, 08 Nov 2022 12:48:32 +0600
+
 wb-update-manager (1.2.5-upgrade5) stable; urgency=medium
 
   * break Debian release update process if updated tool is available

--- a/wb/update_manager/release.py
+++ b/wb/update_manager/release.py
@@ -248,6 +248,11 @@ def update_first_stage(assume_yes=False, log_filename=None):
 
                  Make sure you have all your data backed up.""").strip(), assume_yes)
 
+    # create flag which allows old wb-update-manager to finish upgrade (from less than 1.2.5~upgrade5).
+    # This is required only for bullseye-transitional version of wb-update-manager.
+    with open("/run/wb-release-tool-updated", "wb"):
+        pass
+
     logger.info('Performing upgrade on the current release')
     run_system_update(assume_yes)
 


### PR DESCRIPTION
Починил сломанную процедуру смены релиза WB в переходном репозитории (@Bugoon нашёл проблему). Сломалось об костыль, который заставлял пользователей перезапускать `wb-release`, если скрипт обновился во время перехода на bullseye.