### PR TITLE
run all commands with C locale by default

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-update-manager (1.2.5-upgrade7) stable; urgency=medium
+
+  * run all commands with C locale by default
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Wed, 09 Nov 2022 21:06:35 +0600
+
 wb-update-manager (1.2.5-upgrade6) stable; urgency=medium
 
   * fix updated wb-release's panic during release switch within stretch

--- a/wb/update_manager/release.py
+++ b/wb/update_manager/release.py
@@ -400,6 +400,11 @@ def run_cmd(*args, env=None, log_suffix=None):
 
     proc_logger = logger.getChild(log_suffix)
 
+    if env is None:
+        env = {}
+
+    env['LANG'] = 'C'
+
     proc = subprocess.Popen(args,
                             env=env,
                             stdout=subprocess.PIPE,


### PR DESCRIPTION
По умолчанию команды запускались с той локалью, которая была прописана в env. В некоторых случаях символы из UTF-8 ломали запись в лог (если консоль по умолчанию не умеет в UTF, например, через дебаг или putty), потому их пришлось выкидывать из вывода. Соответственно, при настроенной русской локали в логах почти ничего не осталось.

В качестве временного решения будем запускать все команды с сишной локалью, чтобы UTF-8 не пробивался наружу вообще.

Это не очень красиво, но пока считаю самым простым и действенным вариантом.