### PR TITLE
ease out the free space requirements before Debian release update

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-update-manager (1.2.5-upgrade8) stable; urgency=medium
+
+  * ease out the free space requirements before Debian release update
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Wed, 23 Nov 2022 13:55:04 +0600
+
 wb-update-manager (1.2.5-upgrade7) stable; urgency=medium
 
   * run all commands with C locale by default

--- a/wb/update_manager/release.py
+++ b/wb/update_manager/release.py
@@ -484,8 +484,12 @@ def upgrade_new_debian_release(state: SystemState, log_filename, assume_yes=Fals
     SERVICES_TO_RESTART = ('nginx.service', 'mosquitto.service', 'wb-mqtt-mbgate.service')
     MASKED_SERVICES = ('nginx.service', 'mosquitto.service', 'hostapd.service', 'wb-mqtt-mbgate.service')
 
+    # these values were checked using binary search on configuration with all standard software
+    # with different volumes on / and /var (not fully correct, but still representative).
+    # minimal working solution was 125 MB for root and 300 MB for /var.
+    # I add a little bit of extra requirement on root to be on a safe side.
     MIN_CACHE_FREE_SPACE_MB = 300
-    MIN_SYSTEM_FREE_SPACE_MB = 300
+    MIN_SYSTEM_FREE_SPACE_MB = 150
 
     if _free_space_mb('/var/cache/apt/archives') < MIN_CACHE_FREE_SPACE_MB:
         logger.error('Need at least %d MB of free space for apt cache (/mnt/data)', MIN_CACHE_FREE_SPACE_MB)


### PR DESCRIPTION
Провёл эксперимент с бинарным поиском с отдельными разделами на `/` и `/var`, получилось валидно обновиться при 125 МБ на `/` и `300` на `/var`.

Должно облегчить обновление в отдельных случаях, хотя и добавляет рисков.