### PR TITLE
fix dpkg-reconfigure not found error

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-update-manager (1.2.5-upgrade14) stable; urgency=medium
+
+  * fix dpkg-reconfigure not found error
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Thu, 16 Mar 2023 13:00:55 +0600
+
 wb-update-manager (1.2.5-upgrade13) stable; urgency=medium
 
   * add hostapd service manual enabling after unmasking 

--- a/wb/update_manager/tools.py
+++ b/wb/update_manager/tools.py
@@ -55,4 +55,4 @@ def systemd_restart(*services):
 
 
 def dpkg_reconfigure(package):
-    run_cmd("dpkg-reconfigure", "-f", "noninteractive", package, log_suffix="dpkg-reconfigure")
+    run_cmd("/usr/sbin/dpkg-reconfigure", "-f", "noninteractive", package, log_suffix="dpkg-reconfigure")


### PR DESCRIPTION
В #30 сломан вызов dpkg-reconfigure, утилита лежит в `/usr/sbin` и `path` туда не дотягивается.