### PR TITLE
fix ModemManager installation during upgrade from stretch

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-update-manager (1.2.5-upgrade15) stable; urgency=medium
+
+  * fix ModemManager installation during upgrade from stretch
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Mon, 20 Mar 2023 13:31:45 +0600
+
 wb-update-manager (1.2.5-upgrade14) stable; urgency=medium
 
   * fix dpkg-reconfigure not found error

--- a/wb/update_manager/bullseye.py
+++ b/wb/update_manager/bullseye.py
@@ -168,7 +168,7 @@ def create_temp_apt_configs():
 
                 Package: *
                 Pin: release o=Debian,n=bullseye*
-                Pin-Priority: 600"""
+                Pin-Priority: 501"""  # this must be < 510 in order to install backports deps properly
             ).strip()
         )
 


### PR DESCRIPTION
Заметил, что при переходе на bullseye modemmanager и wb-nm-helper устанавливаются только после ручного обновления уже после перехода. Причина - для backport-пакетов, нужных для modemmanager, стоит приоритет 510, а для bullseye-пакетов стоял 600. Исправил.