### PR TITLE
version bump to upgrade from 1.2.5-wb1; no functional changes

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-update-manager (1.2.5-wb1-upgrade16) stable; urgency=medium
+
+  * version bump to upgrade from 1.2.5-wb1; no functional changes
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Mon, 03 Apr 2023 12:16:09 +0600
+
 wb-update-manager (1.2.5-upgrade15) stable; urgency=medium
 
   * fix ModemManager installation during upgrade from stretch


### PR DESCRIPTION
В wb-2207 была версия `1.2.5-wb1`, с неё не делается апгрейд до `1.2.5-upgrade16` из-за сравнения версий. Делаю бамп