### PR TITLE
fix invoke-rc.d not found error

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-update-manager (1.2.5-wb1-upgrade17) stable; urgency=medium
+
+  * fix invoke-rc.d not found error
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Mon, 03 Apr 2023 18:36:33 +0600
+
 wb-update-manager (1.2.5-wb1-upgrade16) stable; urgency=medium
 
   * version bump to upgrade from 1.2.5-wb1; no functional changes

--- a/wb/update_manager/release.py
+++ b/wb/update_manager/release.py
@@ -260,7 +260,7 @@ def update_second_stage(state: SystemState, old_state: SystemState, assume_yes=F
 
     logger.info("Restarting wb-rules to show actual release info in MQTT")
     try:
-        run_cmd("invoke-rc.d", "wb-rules", "restart")
+        run_cmd("/usr/sbin/invoke-rc.d", "wb-rules", "restart")
     except subprocess.CalledProcessError:
         pass
 


### PR DESCRIPTION
Чинит проблему в stable:

```
12:44:54 Restarting wb-rules to show actual release info in MQTT
12:44:54 Something went wrong, check output and try again
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/wb/update_manager/release.py", line 275, in update_system
    return update_second_stage(target_state, old_state, assume_yes=assume_yes)
  File "/usr/lib/python3/dist-packages/wb/update_manager/release.py", line 263, in update_second_stage
    run_cmd("invoke-rc.d", "wb-rules", "restart")
  File "/usr/lib/python3/dist-packages/wb/update_manager/common.py", line 151, in run_cmd
    with subprocess.Popen(args, env=env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT) as proc:
  File "/usr/lib/python3.5/subprocess.py", line 676, in __init__
    restore_signals, start_new_session)
  File "/usr/lib/python3.5/subprocess.py", line 1282, in _execute_child
    raise child_exception_type(errno_num, err_msg)
FileNotFoundError: [Errno 2] No such file or directory: 'invoke-rc.d'
```