### PR TITLE
Fix release file access issue

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-update-manager (1.3.3) stable; urgency=medium
+
+  * Fix release file access issue due to security reasons
+
+ -- Ekaterina Volkova <ekaterina.volkova@wirenboard.ru>  Tue, 06 Feb 2024 17:39:12 +0300
+
 wb-update-manager (1.3.2) stable; urgency=medium
 
   * Fix PKG-INFO

--- a/wb/update_manager/release.py
+++ b/wb/update_manager/release.py
@@ -342,10 +342,11 @@ def update_second_stage(state: SystemState, old_state: SystemState, assume_yes=F
 
 def release_exists(state: SystemState):
     full_url = make_full_repo_url(state) + "/dists/{}/Release".format(state.suite)
+    request = urllib.request.Request(url=full_url, headers={"User-Agent": "Mozilla/5.0"})
     logger.info("Accessing %s...", full_url)
 
     try:
-        with urllib.request.urlopen(full_url, timeout=10.0) as resp:
+        with urllib.request.urlopen(request, timeout=10.0) as resp:
             logger.info("Response code %d", resp.getcode())
     except HTTPError as e:
         if e.code >= 400 and e.code < 500:


### PR DESCRIPTION
Кажется у сервера срабатывает проверка на ботов и он отклоняет запрос из скрипта, при этом в браузере все работает. Умные люди в интернете пишут, что надо добавить заголовок