### PR TITLE
Fix postinst script

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-update-manager (1.3.8) stable; urgency=medium
+
+  * Fix postinst script
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Wed, 15 Apr 2026 16:40:00 +0400
+
 wb-update-manager (1.3.7) stable; urgency=medium
 
   * Enable angry pylint. No functional changes 

--- a/debian/wb-update-manager.postinst
+++ b/debian/wb-update-manager.postinst
@@ -6,7 +6,7 @@ set -e
 
 rm -rf /etc/update-motd.d/99-wb-bullseye-available
 
-# Allow to install armhf packages on wb8
+# Allow installing armhf packages on arm64 systems
 if [[ $(dpkg --print-architecture) = "arm64" ]]; then
     dpkg --add-architecture armhf
 fi

--- a/debian/wb-update-manager.postinst
+++ b/debian/wb-update-manager.postinst
@@ -7,6 +7,6 @@ set -e
 rm -rf /etc/update-motd.d/99-wb-bullseye-available
 
 # Allow to install armhf packages on wb8
-if [[ $(awk -F= '/TARGET/ {print $2}' /usr/lib/wb-release) =~ ^wb8/ ]]; then
+if [[ $(dpkg --print-architecture) = "arm64" ]]; then
     dpkg --add-architecture armhf
 fi


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
смотреть на TARGET из /usr/lib/wb-release ненадежно, в случае использования тестингсета у нас нет разделения на wb7/wb8 и в TARGET всегда будет wb6 => armhf не будет добавлен

___________________________________
**Что поменялось для пользователей:**
ничего

___________________________________
**Как проверял/а:**


