### PR TITLE
Update debian-archive-keyring

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,4 +3,6 @@ buildDebArchAll defaultRunPythonChecks: true,
                 defaultRunCoverage: true,
                 defaultAngryPylint: true,
                 defaultCoverageMin: "90",
-                defaultDoCoverallsReporting: true
+                defaultDoCoverallsReporting: true,
+                defaultDebianRelease: 'bullseye',
+                defaultWbdevImage: 'contactless/devenv:latest_bullseye'

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-update-manager (1.4.0-upgrade3) stable; urgency=medium
+
+  * Update debian-archive-keyring
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Wed, 10 Jun 2026 10:40:00 +0400
+
 wb-update-manager (1.4.0-upgrade2) stable; urgency=medium
 
   * Add trixie upgrade features

--- a/wb/update_manager/release_upgrade.py
+++ b/wb/update_manager/release_upgrade.py
@@ -142,20 +142,26 @@ def upgrade_and_maybe_switch_tool(assume_yes, log_filename=None):
 TEMP_UPGRADE_SOURCES_LIST = "/etc/apt/sources.list.d/000wb-trixie-upgrade.list"
 TEMP_UPGRADE_APT_PREFERENCES = "/etc/apt/preferences.d/000wb-trixie-upgrade"
 TEMP_UPGRADE_APT_CONFIG = "/etc/apt/apt.conf.d/000wb-trixie-upgrade"
+TEMP_BOOTSTRAP_SOURCES_LIST = "/etc/apt/sources.list.d/000wb-trixie-keyring-bootstrap.list"
+
+
+def _write_temp_upgrade_sources(filename, trusted=False):
+    trusted_arg = "[trusted=yes] " if trusted else ""
+    logger.info("Creating temp sources list for Trixie on %s", filename)
+    with open(filename, "w", encoding="utf-8") as f:
+        f.write(
+            textwrap.dedent(
+                f"""
+                deb {trusted_arg}http://debian-mirror.wirenboard.com/debian trixie main
+                deb {trusted_arg}http://debian-mirror.wirenboard.com/debian trixie-updates main
+                deb {trusted_arg}http://debian-mirror.wirenboard.com/debian trixie-backports main
+                deb {trusted_arg}http://debian-mirror.wirenboard.com/debian-security trixie-security main"""
+            ).strip()
+        )
 
 
 def create_temp_apt_configs():
-    logger.info("Creating temp sources list for Trixie on %s", TEMP_UPGRADE_SOURCES_LIST)
-    with open(TEMP_UPGRADE_SOURCES_LIST, "w", encoding="utf-8") as f:
-        f.write(
-            textwrap.dedent(
-                """
-                deb http://deb.debian.org/debian trixie main
-                deb http://deb.debian.org/debian trixie-updates main
-                deb http://deb.debian.org/debian trixie-backports main
-                deb http://security.debian.org/debian-security trixie-security main"""
-            ).strip()
-        )
+    _write_temp_upgrade_sources(TEMP_UPGRADE_SOURCES_LIST, trusted=False)
 
     logger.info("Creating temp apt preferences for Trixie on %s", TEMP_UPGRADE_APT_PREFERENCES)
     with open(TEMP_UPGRADE_APT_PREFERENCES, "w", encoding="utf-8") as f:
@@ -181,6 +187,19 @@ def remove_temp_apt_configs():
     os.remove(TEMP_UPGRADE_SOURCES_LIST)
     os.remove(TEMP_UPGRADE_APT_PREFERENCES)
     os.remove(TEMP_UPGRADE_APT_CONFIG)
+
+
+def bootstrap_debian_archive_keyring(assume_yes):
+    logger.info("Bootstrapping debian-archive-keyring from trixie to refresh apt keys")
+    _write_temp_upgrade_sources(TEMP_BOOTSTRAP_SOURCES_LIST, trusted=True)
+
+    try:
+        apt_update()
+        apt_install("debian-archive-keyring", assume_yes=assume_yes)
+    finally:
+        logger.info("Removing temporary trusted sources list %s", TEMP_BOOTSTRAP_SOURCES_LIST)
+        os.remove(TEMP_BOOTSTRAP_SOURCES_LIST)
+        _cleanup_apt_cached_lists()
 
 
 @contextmanager
@@ -335,6 +354,8 @@ def actual_upgrade(current_state, new_state, assume_yes=False):
         .strip(),
         assume_yes,
     )
+
+    bootstrap_debian_archive_keyring(assume_yes=True)
 
     with ExitStack() as stack:
         # these operation order is not important


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
apt update из trixie репы не пройдет без свежих ключей, поэтому сначала обновляем debian-archive-keyring без проверки подписи (с `trusted=yes`)

___________________________________
**Что поменялось для пользователей:**


___________________________________
**Как проверял/а:**


