### PR TITLE
Replace python3-json-rpc with python3-jsonrpc

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-update-manager (1.4.0-upgrade4) stable; urgency=medium
+
+  * Replace python3-json-rpc with python3-jsonrpc
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Mon, 22 Jun 2026 10:40:00 +0400
+
 wb-update-manager (1.4.0-upgrade3) stable; urgency=medium
 
   * Update debian-archive-keyring

--- a/wb/update_manager/release_upgrade.py
+++ b/wb/update_manager/release_upgrade.py
@@ -245,6 +245,9 @@ def main_upgrade(assume_yes):
 
     apt_update()
 
+    # replace obsolete jsonrpc package with new one
+    apt_install("python3-jsonrpc", "python3-json-rpc-", assume_yes=True)
+
     if not assume_yes:
         logger.info("Simulating upgrade")
         run_cmd("apt", "dist-upgrade", "-s", "-V")

--- a/wb/update_manager/release_upgrade.py
+++ b/wb/update_manager/release_upgrade.py
@@ -246,7 +246,7 @@ def main_upgrade(assume_yes):
     apt_update()
 
     # replace obsolete jsonrpc package with new one
-    run_cmd("/usr/bin/dpkg", "--remove", "--force-depends", "python3-json-rpc")
+    run_cmd("dpkg", "--remove", "--force-depends", "python3-json-rpc", env=os.environ.copy())
     apt_install(assume_yes=True, fix_broken=True)
 
     if not assume_yes:

--- a/wb/update_manager/release_upgrade.py
+++ b/wb/update_manager/release_upgrade.py
@@ -246,7 +246,7 @@ def main_upgrade(assume_yes):
     apt_update()
 
     # replace obsolete jsonrpc package with new one
-    run_cmd("dpkg", "--remove", "--force-depends", "python3-json-rpc")
+    run_cmd("/usr/bin/dpkg", "--remove", "--force-depends", "python3-json-rpc")
     apt_install(assume_yes=True, fix_broken=True)
 
     if not assume_yes:

--- a/wb/update_manager/release_upgrade.py
+++ b/wb/update_manager/release_upgrade.py
@@ -246,7 +246,7 @@ def main_upgrade(assume_yes):
     apt_update()
 
     # replace obsolete jsonrpc package with new one
-    run_cmd("dpkg", "--remove", "python3-json-rpc")
+    run_cmd("dpkg", "--remove", "--force-depends", "python3-json-rpc")
     apt_install(assume_yes=True, fix_broken=True)
 
     if not assume_yes:

--- a/wb/update_manager/release_upgrade.py
+++ b/wb/update_manager/release_upgrade.py
@@ -246,7 +246,8 @@ def main_upgrade(assume_yes):
     apt_update()
 
     # replace obsolete jsonrpc package with new one
-    apt_install("python3-jsonrpc", "python3-json-rpc-", assume_yes=True)
+    run_cmd("dpkg", "--remove", "python3-json-rpc")
+    apt_install(assume_yes=True, fix_broken=True)
 
     if not assume_yes:
         logger.info("Simulating upgrade")


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
на некоторых инсталяциях остался старый python3-json-rpc, в булзае он продолжает работать, но в трикси уже надо заменить на python3-jsonrpc
```sh
# wb-diag-collect diag
Traceback (most recent call last):
  File "/usr/bin/wb-diag-collect", line 8, in <module>
    from wb.diag.diag_collect import main  # pylint:disable=wrong-import-position
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/share/wb-diag-collect/wb/diag/diag_collect.py", line 12, in <module>
    from wb.diag import collector, rpc_server
  File "/usr/share/wb-diag-collect/wb/diag/rpc_server.py", line 11, in <module>
    from mqttrpc import dispatcher
  File "/usr/lib/python3/dist-packages/mqttrpc/__init__.py", line 7, in <module>
    from .manager import MQTTRPCResponseManager  # pylint: disable=wrong-import-position
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/mqttrpc/manager.py", line 4, in <module>
    from jsonrpc.exceptions import (
    ...<7 lines>...
    )
  File "/usr/lib/python3/dist-packages/jsonrpc/__init__.py", line 7, in <module>
    from .dispatcher import Dispatcher
  File "/usr/lib/python3/dist-packages/jsonrpc/dispatcher.py", line 9, in <module>
    class Dispatcher(collections.MutableMapping):
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'collections' has no attribute 'MutableMapping'
```

___________________________________
**Что поменялось для пользователей:**
обновление без ошибок

___________________________________
**Как проверял/а:**
на вб

