### PR TITLE
Check free space only on fresh start

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-update-manager (1.4.0-upgrade6) stable; urgency=medium
+
+  * Check free space only on fresh start
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Mon, 29 Jun 2026 10:40:00 +0400
+
 wb-update-manager (1.4.0-upgrade5) stable; urgency=medium
 
   * Add bash completion

--- a/tests/test_release_transition.py
+++ b/tests/test_release_transition.py
@@ -28,6 +28,7 @@ def patch_all_systemish(func):
                 (release_upgrade, "remove_temp_apt_policy_for_tool"),
                 (release_upgrade, "touch_system_update_done_flag"),
                 (release_upgrade, "upgrade_and_maybe_switch_tool"),
+                (release_upgrade, "get_global_progress_flag"),
                 (release_upgrade, "set_global_progress_flag"),
                 (release_upgrade, "install_progress_banner"),
                 (release_upgrade, "release_exists"),
@@ -42,6 +43,7 @@ def patch_all_systemish(func):
 
             kwargs["release_exists_mock"].side_effect = (True,)
             kwargs["enough_free_space_mock"].side_effect = (True,)
+            kwargs["get_global_progress_flag_mock"].side_effect = ("",)
 
             return func(*args, **kwargs)
 
@@ -171,6 +173,19 @@ def test_fail_on_low_free_space(enough_free_space_mock=None, run_cmd_mock=None, 
 
 
 @patch_all_systemish
+def test_no_free_space_check_after_interrupted_transition(
+    get_global_progress_flag_mock=None, enough_free_space_mock=None, run_cmd_mock=None, **_
+):
+    get_global_progress_flag_mock.side_effect = ("error",)
+    enough_free_space_mock.side_effect = (False,)
+
+    run_usual_upgrade(no_preliminary_update=False)
+
+    enough_free_space_mock.assert_not_called()
+    run_cmd_mock.assert_called()
+
+
+@patch_all_systemish
 def test_call_tool_upgrade_on_flag(upgrade_and_maybe_switch_tool_mock=None, run_cmd_mock=None, **_):
     run_usual_upgrade(no_preliminary_update=False)
 
@@ -182,6 +197,18 @@ def test_call_tool_upgrade_on_flag(upgrade_and_maybe_switch_tool_mock=None, run_
 def test_no_tool_upgrade_without_flag(upgrade_and_maybe_switch_tool_mock=None, **_):
     run_usual_upgrade()
     upgrade_and_maybe_switch_tool_mock.assert_not_called()
+
+
+@patch_all_systemish
+def test_no_tool_upgrade_after_interrupted_transition(
+    get_global_progress_flag_mock=None, upgrade_and_maybe_switch_tool_mock=None, run_cmd_mock=None, **_
+):
+    get_global_progress_flag_mock.side_effect = ("error",)
+
+    run_usual_upgrade(no_preliminary_update=False)
+
+    upgrade_and_maybe_switch_tool_mock.assert_not_called()
+    run_cmd_mock.assert_called()
 
 
 @patch_all_systemish

--- a/wb/update_manager/release_upgrade.py
+++ b/wb/update_manager/release_upgrade.py
@@ -323,6 +323,16 @@ def make_trixie_target_state(state: SystemState) -> SystemState:
     return state._replace(target=controller_version + "/trixie")
 
 
+def get_global_progress_flag() -> str:
+    flag = "/var/lib/wb-debian-release-update-in-progress"
+
+    if not os.path.exists(flag):
+        return ""
+
+    with open(flag, encoding="utf-8") as f:
+        return f.read().strip()
+
+
 def set_global_progress_flag(value: str):
     flag = "/var/lib/wb-debian-release-update-in-progress"
 
@@ -382,16 +392,23 @@ def actual_upgrade(current_state, new_state, assume_yes=False):
 def upgrade_new_debian_release(
     state: SystemState, log_filename, assume_yes=False, confirm_steps=False, no_preliminary_update=False
 ):
-    # how to do it only on fresh start? check state of 'initialize'
-    if not enough_free_space():
-        return 1
-
     try:
+        progress_state = get_global_progress_flag()
+        if not progress_state:
+            progress_state = "initialize"
+
+        if progress_state == "initialize" and not enough_free_space():
+            return 1
+
         if not no_preliminary_update:
-            # this may break if apt failed during processes, so should be able to skip it somehow?
-            # or enforce tool installation from trixie inside
-            upgrade_and_maybe_switch_tool(assume_yes, log_filename=log_filename)
-            return 0  # should never be here
+            if progress_state == "initialize":
+                # this may break if apt failed during processes, so should be able to skip it somehow?
+                # or enforce tool installation from trixie inside
+                set_global_progress_flag("initialize")
+                upgrade_and_maybe_switch_tool(assume_yes, log_filename=log_filename)
+                return 0  # should never be here
+
+            logger.info('Skipping preliminary upgrade stage due to progress state "%s"', progress_state)
 
         new_state = make_trixie_target_state(state)
         if not release_exists(new_state):

--- a/wb/update_manager/release_upgrade.py
+++ b/wb/update_manager/release_upgrade.py
@@ -395,10 +395,9 @@ def upgrade_new_debian_release(
     try:
         progress_state = get_global_progress_flag()
         if not progress_state:
+            if not enough_free_space():
+                return 1
             progress_state = "initialize"
-
-        if progress_state == "initialize" and not enough_free_space():
-            return 1
 
         if not no_preliminary_update:
             if progress_state == "initialize":


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Проверяем свободное место только при первом старте, если обновление в процессе отвалилось и остались в состоянии progress, то часть места уже занята скачанными пакетами и можем не пройти повторную проверку на свободное место.

___________________________________
**Что поменялось для пользователей:**


___________________________________
**Как проверял/а:**


