### PR TITLE
Ensure wb-configs is upgraded first

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-update-manager (1.4.0-upgrade8) stable; urgency=medium
+
+  * Ensure wb-configs is upgraded first
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Tue, 21 Jun 2026 16:40:00 +0400
+
 wb-update-manager (1.4.0-upgrade7) stable; urgency=medium
 
   * Skip bootstrapping debian-archive-keyring if it is already recent enough

--- a/wb/update_manager/release_upgrade.py
+++ b/wb/update_manager/release_upgrade.py
@@ -287,6 +287,8 @@ def main_upgrade(assume_yes):
     with mask_services(*services_to_mask):
         logger.info("Performing actual upgrade")
 
+        apt_install("wb-configs", assume_yes=assume_yes)
+
         # There is "Breaks" collision in trixie upgrade which we cannot resolve,
         # so I applied this ugly patch. Old nm breaks new ppp, so when we try to
         # install new ppp or nm, apt-get dies.


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Иногда в первом проходе апгрейда network-manager обновляется до wb-configs, возникает ожидаемый конфликт с ppp и первый проход останавливается, в итоге ко второму проходу апгрейда приходим со старым wb-configs без нужных конфигов для apt чтобы поставить curl из backports:
```sh
$ cat trixie-upgrade.log | grep 'Calculating upgrade...\|wb-configs\|breaks'

15:15:06 Calculating upgrade...
15:15:10   vim-runtime watchdog wb-configs wb-device-manager wb-diag-collect
15:15:24 Get:32 https://deb.wirenboard.com/wb8/trixie testing/main arm64 wb-configs all 3.52.4 [52.0 kB]
15:17:12  network-manager (1.42.4-1~bpo11+1-wb103) breaks ppp (>= 2.4.9-2~) and is installed.

15:22:37 Calculating upgrade...
15:22:40   vim vim-common vim-runtime watchdog wb-configs wb-device-manager
15:25:37 Preparing to unpack .../4-wb-configs_3.52.4_all.deb ...
15:25:39 Unpacking wb-configs (3.52.4) over (3.50.2) ...
15:25:50 Setting up wb-configs (3.52.4) ...
15:25:51 Installing new version of config file /etc/wb-configs.d/01wb-configs ...
15:25:52 Removing 'diversion of /etc/ssh/sshd_config to /etc/ssh/sshd_config.wb-orig by wb-configs'
15:25:52 Removing 'diversion of /etc/lirc/hardware.conf to /etc/lirc/hardware.conf.wb-orig by wb-configs'
15:25:52 Removing 'diversion of /etc/nfc/libnfc.conf to /etc/nfc/libnfc.conf.wb-orig by wb-configs'
15:25:54 Adding 'diversion of /etc/ssh/sshd_config to /etc/ssh/sshd_config.wb-orig by wb-configs'
15:30:40 Installing new version of config file /etc/wb-configs.d/15wb-mqtt-confed ...
15:31:02 Installing new version of config file /etc/wb-configs.d/21wb-homeui-backend ...
15:32:12 Reconfiguring new wb-configs to enable its services back
15:32:14 Removing 'diversion of /etc/ssh/sshd_config to /etc/ssh/sshd_config.wb-orig by wb-configs'
15:32:16 Adding 'diversion of /etc/ssh/sshd_config to /etc/ssh/sshd_config.wb-orig by wb-configs'
```

___________________________________
**Что поменялось для пользователей:**
wb-configs обновляется в самом начале, чтобы гарантировано прийти на второй проход со свежими конфигами.

___________________________________
**Как проверял/а:**
на вб

